### PR TITLE
docs: record v0.6.4 publication evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.4 - 2026-07-23 (installed local candidate)
+## 0.6.4 - 2026-07-23 (public Latest release)
 
 ### Changed
 
@@ -23,12 +23,14 @@
 - TypeScript and the production main/preload/Renderer build pass. Seven focused files / 55 tests cover provider draft discovery, local-ID collisions, 401/timeout/oversize handling, Review index/detail/stale snapshots, the 850-file index, Scheduler health and Renderer stores/comments.
 - The release PR's first Windows run exposed the 8.3/long-path alias mismatch above. The corrected four affected service suites pass 27/27 both with the ordinary local temp directory and with an explicit 8.3 short-name `%TEMP%` fixture.
 - The subsequent hosted security gate exposed the new dependency advisories. After resolving `@hono/node-server` to 2.0.11 and `fast-uri` to 3.1.4, `npm audit` reports zero vulnerabilities; TypeScript and the complete 291-test offline suite still pass locally.
-- The pull-request code-scanning policy then surfaced four high and seven medium findings in changed code. The affected parser, TOML patcher and six offline CDP probes were corrected; script syntax checks, TypeScript, 6 focused tests, the 243-file public scan and zero-vulnerability audit pass locally before hosted CodeQL re-evaluation.
+- The pull-request code-scanning policy then surfaced four high and seven medium findings in changed code. The affected parser, TOML patcher and six offline CDP probes were corrected; script syntax checks, TypeScript, 6 focused tests, the 243-file public scan and zero-vulnerability audit pass locally, and hosted CodeQL plus the code-scanning policy completed successfully with no open new PR alerts.
 - The isolated 0.6.4 source fixture passes Dashboard → chat → recent file preview → explicit editor → chat → task center → chat, the four-tool right launcher, non-Git Review, 1280×720/1440×810@125%/1920×1080@200% composer bounds, a visible 1100 px drawer and the provider-manager preset/draft workflow. No model request is sent.
 - The one final offline suite passed 291 tests with 2 explicit opt-in/live tests skipped (60 files passed, 1 skipped) using one Windows worker. The final public-source scan passed 243 text files after adding the installed-version probe.
 - The sole formal package passed Electron Fuses and both public-source/artifact scans. The packaged and installed 0.6.4 fixtures pass the navigation cycle, recent-file preview/editor return, four-tool right pane, non-Git Review, responsive composer/drawer and provider manager.
 - Per-user installation succeeded at `%LOCALAPPDATA%\Programs\Grok Build Desktop`. File/Product/Main/About versions report 0.6.4, diagnostics reports “可以使用”, attachment privacy exclusions remain present, and desktop/Start Menu shortcuts target the installation directory.
 - Final local artifacts: Setup `be0080e4ce0d44528840fa6923e469b26407327d246bbf140e6f761bd76a8ca5`; Portable `1d6104e3ffdad4ae1cc5ca7c80f5352a3e8c63d7e72cb69df55bbc16837480c6`; CycloneDX SBOM `feb7207c0ed97e931fa31a54090658a5ba3aea701fb9af41add6f12817532b67`; third-party licenses `fb8469bdbecff72100bd94c44b2f67f1b596ade9854d95ce862a7559d3b1d82e`. Named 0.6.0–0.6.3 Setup/Portable/SBOM assets remain in `release`.
+- PR #13 merged to `main` at `df5db6b` after Windows, gitleaks, CodeQL and code-scanning checks passed. Tagged workflow `29993675891` rebuilt and scanned the unsigned artifacts, attested Setup/Portable, created a Draft, downloaded it, verified `SHA256SUMS.txt` and provenance, and only then published `v0.6.4` as Latest.
+- Public GitHub assets: Setup `ab4d037a8398ec8c12fc2365efba5ea8c4fae582486dd95f5cd27f8fc8eea1ab`; Portable `635147fafa85b9a0bd4c7d61c9a36a9bb50e4c83410c225ddddccee769945b71`; CycloneDX SBOM `5b789491ac459a0119fcf9f3b62e7140c35ef601d271e65fc6dd57b726b6dae0`; third-party licenses `e86a7b4249bd018f743e8c347e7b555cda81c3208c508e32810a91075d49942b`.
 
 ## 0.6.3 - 2026-07-23 (installed local hotfix)
 

--- a/docs/CLI_COMPATIBILITY.md
+++ b/docs/CLI_COMPATIBILITY.md
@@ -20,11 +20,11 @@
 | 2026-07-22 | 0.2.106 (`bde89716f6`) | Local app 0.6.1 candidate | No new required CLI method. Pasted images still reach ACP as standard image content blocks; `clientMessageId`, durable previews, queue/interjection presentation and cache cleanup are desktop contracts. ACP image replay is merged client-side and cache paths are excluded from prompt text. Final package/installed acceptance is offline and sends no model prompt. |
 | 2026-07-22 | 0.2.106 (`bde89716f6`) | Local app 0.6.2 development candidate | No new paid/private ACP requirement. Turn duration/outcome is Desktop presentation metadata. Review uses local Git through fixed main-process argument arrays and stdin; Renderer sends only typed scope/file/hunk IDs. Last turn intersects current Git changes with actual ACP write locations. |
 | 2026-07-23 | 0.2.106 (`bde89716f6`) | Local app 0.6.3 installed hotfix | No ACP wire change. Scheduler decoding/diagnostics and unified Renderer navigation are Desktop/Windows fixes; non-Git Review capability checks use local Git only. |
-| 2026-07-23 | 0.2.106 (`bde89716f6`) | Local app 0.6.4 candidate | No new ACP/private-method requirement. Lazy Review index/detail remains local fixed-argument Git. Provider draft testing/discovery is a bounded main-process GET to the configured model-list endpoint and never sends inference content; Renderer receives typed candidates without credentials. |
+| 2026-07-23 | 0.2.106 (`bde89716f6`) | Public app 0.6.4 release | No new ACP/private-method requirement. Lazy Review index/detail remains local fixed-argument Git. Provider draft testing/discovery is a bounded main-process GET to the configured model-list endpoint and never sends inference content; Renderer receives typed candidates without credentials. PR #13 and Release workflow `29993675891` passed; `v0.6.4` is the public Latest release at `df5db6b`. |
 
 Every accepted CLI update must pass `initialize` and `session/new`; a version banner alone is not sufficient.
 
-## v0.6 local-candidate capability snapshot (2026-07-22)
+## v0.6 accepted capability snapshot (2026-07-23)
 
 Installed CLI `0.2.106 (bde89716f6)` advertises Worktree creation/resume flags, `grok worktree list/show/rm/gc`, experimental cross-session Memory, Agent definitions, Personas and the Agent Dashboard. Its bundled official ACP guide lists `x.ai/git/*` and `x.ai/git/worktree/create|remove|apply|list|gc`, while `grok inspect --json` reports agents, skills, plugins, MCP/LSP servers, configuration sources and project trust. The v0.6 client capability-probes private methods and provides the controlled Git/read-only-history fallbacks defined below; it never launches `grok dashboard`.
 

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -1,17 +1,17 @@
 # Feature Matrix
 
-## v0.6.3 installed hotfix / v0.6.4 installed local candidate
+## v0.6.4 public stable release / installed local build
 
 | Area | Status | Notes |
 |---|---|---|
 | Scheduler diagnostics | 0.6.3 installed/verified | UTF-8/UTF-16/GB18030-compatible Buffer decoding, structured stable diagnostics and damaged-history replacement remove task-center mojibake; focused encoding/health tests pass. |
-| Conversation navigation/layout | 0.6.3 installed + 0.6.4 source UI verified | Unified target opening and fixed conversation grid preserve the Virtuoso viewport, composer and focus. The 0.6.4 fixture passes Dashboard→chat→file preview→explicit editor→chat→task center→chat. |
-| Multi-tool right pane | Source UI verified | On-demand launcher exposes only Review, plan/result, recent files and side tasks. Width is 420–760 px per tool; 1100 px uses a visible overlay drawer instead of CSS-hiding the panel. |
-| Scalable Review | Focused/source UI verified | Lightweight index plus one selected `GitReviewFileDetail`; search/status/stats and lazy hunks handle the 850-file fixture. Five scopes, stale-snapshot protection, hunk actions and comments remain main-process-backed. Non-Git is an ordinary empty state. |
-| Provider manager | Focused/source UI verified | Independent searchable manager with five presets, unsaved-draft probe/discovery, structured environment headers, candidate multi-select/import, editable collision-safe local IDs, manual fallback and unknown context windows. |
+| Conversation navigation/layout | Public source + installed UI verified | Unified target opening and fixed conversation grid preserve the Virtuoso viewport, composer and focus. The 0.6.4 fixture passes Dashboard→chat→file preview→explicit editor→chat→task center→chat. |
+| Multi-tool right pane | Public source + installed UI verified | On-demand launcher exposes only Review, plan/result, recent files and side tasks. Width is 420–760 px per tool; 1100 px uses a visible overlay drawer instead of CSS-hiding the panel. |
+| Scalable Review | Public/focused/UI verified | Lightweight index plus one selected `GitReviewFileDetail`; search/status/stats and lazy hunks handle the 850-file fixture. Five scopes, stale-snapshot protection, hunk actions and comments remain main-process-backed. Non-Git is an ordinary empty state. |
+| Provider manager | Public/focused/UI verified | Independent searchable manager with five presets, unsaved-draft probe/discovery, structured environment headers, candidate multi-select/import, editable collision-safe local IDs, manual fallback and unknown context windows. |
 | Provider probe security | Focused-tested | Main process performs bounded model-list GET only, rejects redirects, limits timeout/2 MiB response, supports OpenAI/Anthropic/Ollama list shapes and keeps credentials out of logs/diagnostics. |
 | Windows path aliases | Focused/Hosted regression verified | Existing absolute paths are canonicalized before workspace comparison, so 8.3 `%TEMP%` aliases and long `realpath` results refer to the same Editor/Memory/Agent/Git boundary. Symlink and junction escapes remain rejected. |
-| 0.6.4 delivery | Installed and verified | Source/lockfile/display/File/Product/Main/About are 0.6.4. TypeScript, production build, 7 focused files / 55 tests, expanded source/packaged/installed UI fixtures, one final offline suite (291 pass/2 opt-in skip), Fuses, the final 243-file source scan and artifact scans pass. Per-user install, diagnostics ready, attachment privacy and both shortcut targets pass; final hashes are in `release/SHA256SUMS.txt` and the Changelog. |
+| 0.6.4 delivery | Published Latest + installed and verified | PR #13 merged at `df5db6b` after Windows, gitleaks, CodeQL and code-scanning gates. Release workflow `29993675891` rebuilt, scanned, attested, draft-downloaded and hash/provenance-verified all five assets before publishing `v0.6.4` as Latest. Public Setup SHA-256 is `ab4d037a8398ec8c12fc2365efba5ea8c4fae582486dd95f5cd27f8fc8eea1ab`; Portable is `635147fafa85b9a0bd4c7d61c9a36a9bb50e4c83410c225ddddccee769945b71`. |
 
 ## v0.6.2 local candidate
 
@@ -59,7 +59,7 @@
 | Codex continuation identity | Implemented and focused-tested | New Grok continuations preserve the exact original Codex title; multiple continuation mappings migrate without modifying source JSONL |
 | Reusable task sessions | Packaged-live verified | Reuse is the default; two consecutive real OAuth task runs completed against the same resumable Grok session instead of creating two sessions |
 | Task context lifecycle | Implemented and tested | Per-task retain/fresh policy, direct open, manual permanent cleanup, stale/history migration and task-lock protection; packaged live cleanup removed the dedicated session and mapping |
-| Public release evidence | Published and externally verified | `v0.5.16` is the Latest public Release at commit `e4dfb62`; workflow `29846404781` succeeded and published Setup/Portable, SHA-256, SBOM, licenses and provenance |
+| Historical public release evidence | Published and externally verified | `v0.5.16` was published at commit `e4dfb62` by workflow `29846404781` with Setup/Portable, SHA-256, SBOM, licenses and provenance; it was superseded as Latest by `v0.6.4` on 2026-07-23. |
 
 ## v0.5.15 hotfix
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -36,13 +36,15 @@
 - [x] 唯一一次正式 0.6.4 打包通过 Electron Fuses、源码/产物扫描并生成 Setup、Portable、SHA-256、SBOM 和许可证报告；0.6.0–0.6.3 命名资产全部保留。
 - [x] `win-unpacked` 夹具通过后完成 per-user 安装；文件/Product/Main/About 为 0.6.4，诊断为“可以使用”，桌面/开始菜单快捷方式指向安装目录，安装版 0.6.4 UI 夹具通过。
 - [x] 正式发布 PR 的 Hosted Windows `%TEMP%` 8.3 路径暴露长短路径比较问题；统一 canonical path 边界后，Editor、Memory、Agent/Persona、Git 四组 27 项测试在普通与显式短路径临时目录下均通过，符号链接/目录联接逃逸继续拒绝。
-- [x] 正式发布安全门禁发现新公布的 `@hono/node-server` 路径穿越与 `fast-uri` 主机混淆公告；固定到已修复版本后 `npm audit` 为 0，TypeScript 与完整 291 项离线测试继续通过，等待 Hosted Windows 复核后合并发布。
-- [x] PR 代码扫描策略进一步识别 4 个高危与 7 个中危问题；将 Diff 头解析改为线性扫描、修复 TOML 空白匹配，并把六个 CDP 探针的动态值改为 `Runtime.callFunctionOn` 参数。脚本语法、TypeScript、6 项聚焦测试、243 文件公开扫描与零漏洞审计本地通过，等待 Hosted CodeQL 复核。
+- [x] 正式发布安全门禁发现新公布的 `@hono/node-server` 路径穿越与 `fast-uri` 主机混淆公告；固定到已修复版本后 `npm audit` 为 0，TypeScript 与完整 291 项离线测试继续通过，Hosted Windows 复核通过。
+- [x] PR 代码扫描策略进一步识别 4 个高危与 7 个中危问题；将 Diff 头解析改为线性扫描、修复 TOML 空白匹配，并把六个 CDP 探针的动态值改为 `Runtime.callFunctionOn` 参数。脚本语法、TypeScript、6 项聚焦测试、243 文件公开扫描与零漏洞审计本地通过；Hosted CodeQL 分析和代码扫描策略复核为成功且 PR 无开放新警报。
+- [x] PR #13 的 Windows、gitleaks、CodeQL 与代码扫描策略全部通过并合并到 `main` 提交 `df5db6b`；`v0.6.4` 标签触发 workflow `29993675891`，云端重新打包、扫描、attest、Draft 回下载、哈希/provenance 验证通过后公开为 Latest。
 
-### v0.6.4 最终候选说明
+### v0.6.4 最终发布说明
 
 - 未发送付费提示词；提供商 UI 验收没有点击真实网络探测，服务测试只访问本地回环假端点。
-- 最终哈希：Setup `be0080e4ce0d44528840fa6923e469b26407327d246bbf140e6f761bd76a8ca5`；Portable `1d6104e3ffdad4ae1cc5ca7c80f5352a3e8c63d7e72cb69df55bbc16837480c6`；SBOM `feb7207c0ed97e931fa31a54090658a5ba3aea701fb9af41add6f12817532b67`；许可证 `fb8469bdbecff72100bd94c44b2f67f1b596ade9854d95ce862a7559d3b1d82e`。
+- 本地安装候选哈希：Setup `be0080e4ce0d44528840fa6923e469b26407327d246bbf140e6f761bd76a8ca5`；Portable `1d6104e3ffdad4ae1cc5ca7c80f5352a3e8c63d7e72cb69df55bbc16837480c6`；SBOM `feb7207c0ed97e931fa31a54090658a5ba3aea701fb9af41add6f12817532b67`；许可证 `fb8469bdbecff72100bd94c44b2f67f1b596ade9854d95ce862a7559d3b1d82e`。
+- GitHub 公开资产哈希：Setup `ab4d037a8398ec8c12fc2365efba5ea8c4fae582486dd95f5cd27f8fc8eea1ab`；Portable `635147fafa85b9a0bd4c7d61c9a36a9bb50e4c83410c225ddddccee769945b71`；SBOM `5b789491ac459a0119fcf9f3b62e7140c35ef601d271e65fc6dd57b726b6dae0`；许可证 `e86a7b4249bd018f743e8c347e7b555cda81c3208c508e32810a91075d49942b`。
 
 ## v0.6.2：Codex 深度对齐与审核工作流重构（2026-07-22）
 

--- a/docs/NEXT_SESSION_HANDOFF.md
+++ b/docs/NEXT_SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 # Grok Build Desktop 下一会话交接（2026-07-23）
 
-> 当前目标已完成到本地安装版 0.6.4。后续会话不要重复本轮完整离线套件、正式打包或付费模型验收；先复用本文证据，只验证后续实际改动。本文不含账号、Token、提示词正文、Codex 会话内容或本机绝对附件路径。
+> 当前目标已完成到本地安装版和公开 Latest `v0.6.4`。后续会话不要重复本轮完整离线套件、正式打包或付费模型验收；先复用本文证据，只验证后续实际改动。本文不含账号、Token、提示词正文、Codex 会话内容或本机绝对附件路径。
 
 ## 1. 必读与工作树纪律
 
@@ -12,7 +12,7 @@
 6. `docs/CLI_COMPATIBILITY.md`
 7. `CHANGELOG.md`
 
-开始前检查 `git status`。0.6.0–0.6.4 的完整功能工作树仍未提交；不得重置、覆盖或与旧基线混合。本轮没有创建提交、标签、PR、推送或 GitHub Release，公开 Latest 仍是 `v0.5.16`。
+开始前检查 `git status`。0.6.0–0.6.4 功能已通过 PR #13 合并到 `main`，`v0.6.4` 标签位于提交 `df5db6b`；GitHub Release 已公开并标记为 Latest。不要移动或替换已发布标签/资产。
 
 ## 2. 当前版本与本机交付
 
@@ -63,15 +63,27 @@
 
 0.6.0–0.6.3 Setup、Portable 与 SBOM 命名资产仍在 `release`。通用许可证报告和 `SHA256SUMS.txt` 按当前候选更新，这是发布目录的既有约定。
 
-## 7. 仍未完成的外部门槛
+## 7. 公开发布证据
+
+- Release：`https://github.com/wangyingxuan383-ai/grok-build-desktop/releases/tag/v0.6.4`
+- PR #13 合并提交：`df5db6bed55ba317f24cb235aacd342bea7a563d`。
+- Release workflow `29993675891` 成功；云端重新打包、公开产物扫描、Setup/Portable attest、Draft 回下载、`SHA256SUMS.txt` 和 provenance 验证均通过，之后才发布为 Latest。
+- Setup：`ab4d037a8398ec8c12fc2365efba5ea8c4fae582486dd95f5cd27f8fc8eea1ab`
+- Portable：`635147fafa85b9a0bd4c7d61c9a36a9bb50e4c83410c225ddddccee769945b71`
+- CycloneDX SBOM：`5b789491ac459a0119fcf9f3b62e7140c35ef601d271e65fc6dd57b726b6dae0`
+- 第三方许可证：`e86a7b4249bd018f743e8c347e7b555cda81c3208c508e32810a91075d49942b`
+
+本地产物和 GitHub Hosted Runner 产物来自不同构建环境，哈希不同是预期行为；公开分发以 GitHub Release 的清单为准。
+
+## 8. 仍未完成的外部门槛
 
 - Windows 10 22H2、Windows 11 23H2/24H2、中文用户名、标准权限、物理 125–200% DPI 与双屏矩阵。
-- 从公开 `v0.5.16` 到 0.6.4 的正式覆盖升级及真实 DPAPI 账号、持久任务、专属会话、Codex 接力和 AppData 保留矩阵。
-- Git 提交/标签、GitHub Release、云端构建溯源、回下载和外部签名；必须等待用户明确发布指令。
-- 不要把本地 0.6.4 候选描述成公开 Release，不要重复付费 `/remember`、私有 Worktree ACP 或真实提供商推理。
+- 从公开 `v0.5.16` 安装包到公开 `v0.6.4` 安装包的真实覆盖升级，以及 DPAPI 账号、持久任务、专属会话、Codex 接力和 AppData 保留矩阵。
+- Windows Authenticode 外部签名尚未配置；公开资产为工作流明确标注的 unsigned 构建，并有 GitHub artifact attestations。
+- 不要重复付费 `/remember`、私有 Worktree ACP 或真实提供商推理。
 
-## 8. 后续会话开场指令
+## 9. 后续会话开场指令
 
 ```text
-先读取 AGENTS.md、docs/NEXT_SESSION_HANDOFF.md、docs/IMPLEMENTATION_PLAN.md 的 v0.6.3→v0.6.4 章节、docs/FEATURE_MATRIX.md、docs/CODEX_UI_PARITY.md、docs/CLI_COMPATIBILITY.md 和 CHANGELOG.md，并检查 git status。0.6.4 已完成本地安装和最终验证，不要重复完整套件、正式打包或付费验收；只处理我明确要求的后续改动、外部矩阵或发布工作，并运行直接受影响的聚焦验证。
+先读取 AGENTS.md、docs/NEXT_SESSION_HANDOFF.md、docs/IMPLEMENTATION_PLAN.md 的 v0.6.3→v0.6.4 章节、docs/FEATURE_MATRIX.md、docs/CODEX_UI_PARITY.md、docs/CLI_COMPATIBILITY.md 和 CHANGELOG.md，并检查 git status。v0.6.4 已完成本地安装、GitHub 公开 Latest 发布和验证，不要重复完整套件、正式打包或付费验收；只处理我明确要求的后续改动或外部矩阵，并运行直接受影响的聚焦验证。
 ```


### PR DESCRIPTION
Records the verified public Latest release, workflow provenance, public hashes and remaining external validation boundaries after v0.6.4 publication.