### PR TITLE
修复 v0.8.0 正式打包后的 UI 复验超时

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - 诊断中心补齐官方 Grok Doctor 自动修复：只接受 `doctor --json` 返回的安全修复 ID，使用五分钟一次性预览令牌、执行前重新验证和二次确认，以固定参数调用 `doctor fix`；当前机器没有可应用修复。
 - 官方上游快照更新至仓库 `b13fa526f5112c0b20dad5f1f2300d3d3b127895` / 源码 `a51a1dc62fe20029ac39a665985bba78edbb870f`，并加入 Session Rename/标题通知前向 Fixture；审计报告见 `docs/V080_FINAL_AUDIT.md`。
 - 再审后的完整套件为 101 个测试文件/734 项通过（6 个 live 文件/9 项按设计跳过）；TypeScript、资源/生产构建、366 文件公开扫描、分块、Native Host、零漏洞依赖审计、diff check 与当前生产构建 UI 通过。
+- 正式工作流在完成 ZIP/NSIS 重负载后仍会再次运行完整 UI 夹具；CDP 单次诊断上限由 20 秒提高到 60 秒，避免 Hosted Windows 打包后短时繁忙被误判为 Renderer 故障，功能断言和总流程超时保持不变。
 - 建立独立的 CLI 1.x 兼容档案、离线/运行时门禁及 1.0.0/未知未来主版本 Wire Fixture；未知主版本失败关闭，版本号不再被当成功能证据。
 - 受管 ACP 会话按 1.0 重新提交交互式附加策略，解析结构化 `closeOutcome`；MCP 斜杠事件、包装通知、Context/Usage/Session Info、Plan/Stop/Compact/Recap 和恢复后的真实模式均按会话归一化。
 - 官方 Git status 显式请求未跟踪文件、统计、补丁和子模块策略，避免 1.0 默认值改变让 Review 漏文件；官方返回不完整或没有匹配的空闲会话时回退现有受限系统 Git。

--- a/scripts/probe-v070-ui.mjs
+++ b/scripts/probe-v070-ui.mjs
@@ -11,7 +11,7 @@ const socket = new WebSocket(target.webSocketDebuggerUrl);
 await new Promise((resolve, reject) => { socket.onopen = resolve; socket.onerror = reject; });
 let id = 0; const pending = new Map();
 socket.onmessage = ({ data }) => { const message = JSON.parse(data); const entry = pending.get(message.id); if (!entry) return; pending.delete(message.id); message.error ? entry.reject(new Error(message.error.message)) : entry.resolve(message.result); };
-const request = (method, params = {}) => new Promise((resolve, reject) => { const requestId = ++id; const timer = setTimeout(() => reject(new Error(`${method} timed out`)), 20_000); pending.set(requestId, { resolve: (value) => { clearTimeout(timer); resolve(value); }, reject }); socket.send(JSON.stringify({ id: requestId, method, params })); });
+const request = (method, params = {}) => new Promise((resolve, reject) => { const requestId = ++id; const timer = setTimeout(() => reject(new Error(`${method} timed out`)), 60_000); pending.set(requestId, { resolve: (value) => { clearTimeout(timer); resolve(value); }, reject }); socket.send(JSON.stringify({ id: requestId, method, params })); });
 const evaluate = async (expression) => { const result = await request("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true }); if (result.exceptionDetails) throw new Error(result.exceptionDetails.text); return result.result?.value; };
 let runtimeGlobal;
 const refreshRuntimeGlobal = async () => { runtimeGlobal = await request("Runtime.evaluate", { expression: "globalThis", returnByValue: false }); };


### PR DESCRIPTION
## 原因\n\nv0.8.0 正式工作流已经完成 ZIP/NSIS 构建，但打包后再次运行 UI 夹具时，Hosted Windows 的一次 CDP Runtime.evaluate 超过固定 20 秒。\n\n## 修改\n\n- 将 UI 探针单次 CDP RPC 上限提高到 60 秒。\n- 不改变任何功能断言、场景等待或发布流程总上限。\n- 更新 0.8.0 Changelog。\n\n## 本地验证\n\n- node --check scripts/probe-v070-ui.mjs\n- git diff --check\n\n合并后将重新指向 v0.8.0 标签并运行正式发布工作流。