### PR TITLE
ci: verify unpacked app before release compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - 修复 Hosted Windows 打包后 UI 探针在 React 首帧提交前注入合成 `resize`、可能让 Renderer 布局线程持续繁忙的问题：现在先等待原生首帧，再设置确定性验收视口；超时 CDP 请求会从挂起表清理并按总门禁重试，不降低任何界面断言。
 - 发布标签的无交互 Hosted Windows 改用单 Renderer 的打包壳层/真实功能入口探针与 Portable 结构验收；完整 0.8.0 多会话、Plan、权限、Stop、Provider 和响应式 UI 夹具仍由同一提交的 PR/main CI 及本机打包门禁强制执行，避免 ZIP/NSIS 重负载后的虚拟桌面死锁被误判为产品故障。
 - 同步更新 Hosted 打包壳层断言到 0.8.0 信息架构：验证新建任务、折叠开发工具、右栏、任务中心、扩展、创作、设置和 Overlay Host，不再查询已退役且由 CSS 隐藏的 0.6.x 顶栏入口。
+- Windows 正式打包改为两阶段：先生成并验收唯一 `win-unpacked`（Fuses 与 UI），再以 `--prepackaged` 从同一目录生成 Setup/Portable；GUI 验收不再排在 ZIP/NSIS 重压缩之后，既避免 Hosted 虚拟桌面资源枯竭，也保证公开资产来自已验收的同一应用树。
 - 建立独立的 CLI 1.x 兼容档案、离线/运行时门禁及 1.0.0/未知未来主版本 Wire Fixture；未知主版本失败关闭，版本号不再被当成功能证据。
 - 受管 ACP 会话按 1.0 重新提交交互式附加策略，解析结构化 `closeOutcome`；MCP 斜杠事件、包装通知、Context/Usage/Session Info、Plan/Stop/Compact/Recap 和恢复后的真实模式均按会话归一化。
 - 官方 Git status 显式请求未跟踪文件、统计、补丁和子模块策略，避免 1.0 默认值改变让 Review 漏文件；官方返回不完整或没有匹配的空闲会话时回退现有受限系统 Git。

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -5,6 +5,7 @@
 - [x] 正式发布 Hosted Windows 二次打包探针改为“先等待 Renderer 首帧、再设置固定视口”，移除启动竞态中的合成 resize；CDP 超时请求可清理并重试，发布门禁仍执行完整 0.8.0 UI 断言。
 - [x] 标签工作流在无交互 Hosted Windows 上以轻量单 Renderer 验证打包壳层、全部真实功能入口和 Portable 结构；完整多会话/Plan/权限/Stop/Provider/响应式夹具保持为同提交 PR/main CI 与本机打包必过项，不在 ZIP/NSIS 后重复消耗不可靠的虚拟桌面资源。
 - [x] Hosted 壳层探针已迁移至 0.8.0 入口契约：新建任务、开发工具、右栏、任务中心、扩展、创作、设置与 Overlay Host；删除对已退役 0.6.x 顶栏类名的发布依赖。
+- [x] 正式 Windows 打包拆为“目录打包并验收 → 从已验收目录生成 Setup/Portable”两阶段；Fuses/UI 在压缩前验证，`--prepackaged` 保证最终公开资产与被验收应用树一致。
 - [x] 重新逐项核对全部历史实施计划；旧版本遗留的验收、打包和延期复选项已按 0.8.0 的替代证据归档。当前唯一未完成复选项是远程 CPA 上游返回 `403 cpa_local_only`，属于已准确暴露的外部策略边界，不伪装为 Desktop 成功。
 - [x] 复核官方 Changelog、官方开源仓库与已安装 stable：公开发行版仍为 1.0.0；官方 main 相对既有快照新增的唯一重要公共会话扩展是 `x.ai/session/rename` 及标题所有权元数据，没有发现第二个尚未映射的重要稳定公共接口。
 - [x] 增加 `x.ai/session/rename` 前向兼容、标准/私有标题通知归一化和本地旧 CLI 回退；stable 1.0.0 实机返回 method-not-found，因此不显示为稳定可用能力。

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,6 +1,6 @@
 # Grok Build Desktop v0.8.0｜正式版
 
-> 发布构建补充：完整 UI 夹具由同一提交的 PR/main CI 与本机打包门禁执行；标签构建在无交互 Hosted Windows 上额外验证干净打包壳层、真实功能入口、Fuses 和 Portable 结构，避免 ZIP/NSIS 重负载后的虚拟桌面死锁被误判为产品故障。
+> 发布构建补充：完整 UI 夹具由同一提交的 PR/main CI 与本机打包门禁执行；标签构建先验证干净的 unpacked 应用壳层、真实功能入口与 Fuses，再从这个已验收目录生成 Setup/Portable 并校验结构，避免 ZIP/NSIS 重负载耗尽 Hosted 虚拟桌面资源。
 
 这是自公开版 **v0.6.22** 以来的集中大版本更新。0.8.0 完成 Grok Build CLI 1.0.0 适配，并系统收口会话恢复、Plan/权限/停止、并行任务、自定义 Provider、文件审核、媒体、更新中心与高频桌面交互。
 

--- a/scripts/generate-release-assets.ps1
+++ b/scripts/generate-release-assets.ps1
@@ -16,12 +16,12 @@ $Version = (Get-Content (Join-Path $Root 'package.json') -Raw | ConvertFrom-Json
 node (Join-Path $PSScriptRoot 'check-renderer-chunks.mjs')
 if ($LASTEXITCODE -ne 0) { throw '发布资产的 Renderer 分块预算或 Worker 命名门禁失败。' }
 $PackagedExecutable = Join-Path $Release 'win-unpacked\Grok Build Desktop.exe'
-if (-not (Test-Path -LiteralPath $PackagedExecutable -PathType Leaf)) { throw '发布资产缺少 win-unpacked 应用，无法执行当前 v0.7 UI 验收。' }
+if (-not (Test-Path -LiteralPath $PackagedExecutable -PathType Leaf)) { throw '发布资产缺少 win-unpacked 应用，无法执行当前版本 UI 验收。' }
 if (-not $SkipPackagedUiProbe) {
     & (Join-Path $PSScriptRoot 'probe-v070-ui.ps1') -Executable $PackagedExecutable
-    if ($LASTEXITCODE -ne 0) { throw '发布资产的当前 v0.7 UI 验收失败。' }
+    if ($LASTEXITCODE -ne 0) { throw '发布资产的当前版本 UI 验收失败。' }
 } else {
-    Write-Host '复用同一打包流程刚完成的 v0.7 UI 验收，不重复启动相同候选。' -ForegroundColor Cyan
+    Write-Host '复用同一打包流程刚完成的当前版本 UI 验收，不重复启动相同候选。' -ForegroundColor Cyan
 }
 
 $Sbom = Join-Path $Release "Grok-Build-Desktop-$Version-SBOM.cdx.json"

--- a/scripts/package-win.ps1
+++ b/scripts/package-win.ps1
@@ -49,32 +49,37 @@ npm run build
 if ($LASTEXITCODE -ne 0) { throw "生产构建失败 ($LASTEXITCODE)" }
 npm run check:chunks
 if ($LASTEXITCODE -ne 0) { throw "Renderer 分块预算或 Worker 命名门禁失败 ($LASTEXITCODE)" }
-npx electron-builder --win nsis zip --x64 --publish never
-if ($LASTEXITCODE -ne 0) { throw "electron-builder 失败 ($LASTEXITCODE)" }
+npx electron-builder --win --dir --x64 --publish never
+if ($LASTEXITCODE -ne 0) { throw "electron-builder 目录打包失败 ($LASTEXITCODE)" }
 $ExpectedExecutable = Join-Path $Root 'release\win-unpacked\Grok Build Desktop.exe'
 $ExpectedSetup = Join-Path $Root "release\Grok-Build-Desktop-Setup-v$Version-x64.exe"
 $ExpectedZip = Join-Path $Root "release\Grok-Build-Desktop-$Version-x64.zip"
 Wait-ReleaseFile $ExpectedExecutable
-Wait-ReleaseFile $ExpectedSetup
-Wait-ReleaseFile $ExpectedZip
-Remove-Item -LiteralPath (Join-Path $Root 'release\builder-debug.yml'),(Join-Path $Root 'release\builder-effective-config.yaml') -Force -ErrorAction SilentlyContinue
-Get-ChildItem -LiteralPath (Join-Path $Root 'release') -Filter '*.blockmap' -File -ErrorAction SilentlyContinue | Remove-Item -Force
 node (Join-Path $PSScriptRoot 'verify-fuses.mjs') $ExpectedExecutable
 if ($LASTEXITCODE -ne 0) { throw 'Electron Fuses 校验失败。' }
 $HostedActions = $env:GITHUB_ACTIONS -eq 'true'
 if ($HostedActions) {
     # The full current-version fixture is already a required PR/main CI gate
-    # on the same commit. A tag runner has no interactive Windows desktop and
-    # can deadlock a fixture-heavy Renderer after ZIP/NSIS compression even
-    # though the packaged application is healthy. Verify the clean packaged
-    # shell and every real feature entry in one lightweight Renderer here;
-    # local packaging continues to run the complete fixture below.
+    # on the same commit. Verify the clean unpacked application before ZIP/NSIS
+    # compression consumes the hosted virtual desktop's graphics resources.
+    # The tag runner uses one lightweight Renderer; local packaging continues
+    # to run the complete fixture below.
     & (Join-Path $PSScriptRoot 'smoke-app.ps1') -Executable $ExpectedExecutable -ProbeScript 'probe-hosted-release-ui.mjs'
     if ($LASTEXITCODE -ne 0) { throw 'Hosted Windows 打包壳层验收失败。' }
 } else {
     & (Join-Path $PSScriptRoot 'probe-v070-ui.ps1') -Executable $ExpectedExecutable
     if ($LASTEXITCODE -ne 0) { throw '当前 v0.8.0 打包 UI 验收失败。' }
 }
+
+# Generate distributable assets from the exact unpacked directory that passed
+# Fuses and UI verification. This avoids repackaging a different application
+# tree and keeps heavyweight ZIP/NSIS compression after the GUI gate.
+npx electron-builder --win nsis zip --x64 --publish never --prepackaged (Join-Path $Release 'win-unpacked')
+if ($LASTEXITCODE -ne 0) { throw "electron-builder 发布资产打包失败 ($LASTEXITCODE)" }
+Wait-ReleaseFile $ExpectedSetup
+Wait-ReleaseFile $ExpectedZip
+Remove-Item -LiteralPath (Join-Path $Root 'release\builder-debug.yml'),(Join-Path $Root 'release\builder-effective-config.yaml') -Force -ErrorAction SilentlyContinue
+Get-ChildItem -LiteralPath (Join-Path $Root 'release') -Filter '*.blockmap' -File -ErrorAction SilentlyContinue | Remove-Item -Force
 
 $GenericZip = Join-Path $Root "release\Grok-Build-Desktop-$Version-x64.zip"
 $PortableZip = Join-Path $Root "release\Grok-Build-Desktop-Portable-v$Version-x64.zip"
@@ -103,7 +108,7 @@ if ($ReleaseArtifactsOnly) {
     & (Join-Path $PSScriptRoot 'smoke-portable.ps1') -Archive $PortableZip -StructureOnly
 } else {
     & (Join-Path $PSScriptRoot 'smoke-app.ps1') -Executable $ExpectedExecutable
-    # The current v0.7 probe supersedes the legacy v0.4/v0.6 probes. Those
+    # The current-version probe supersedes the legacy v0.4/v0.6 probes. Those
     # scripts encode retired information architecture (for example, exposing
     # Git Review in a non-Git fixture) and must not gate the current release.
     foreach ($OverlayEntry in @('.task-entry', '.extensions-entry', '.media-entry')) {


### PR DESCRIPTION
## 说明
- Windows 正式打包先生成并验收唯一 win-unpacked
- Fuses 与 UI 通过后，再用 electron-builder --prepackaged 生成 Setup/Portable
- 避免 ZIP/NSIS 重压缩耗尽 Hosted Windows 虚拟桌面资源
- 最终公开资产与被验收应用树保持一致

## 本机验证
- .\\scripts\\package-win.ps1 -ReleaseArtifactsOnly
- 完整 0.8.0 UI 夹具通过
- Fuses、Setup、Portable、SHA-256、SBOM、许可证和 366 文件公开扫描通过